### PR TITLE
Fix onLazyInitView() 不会执行的Issue

### DIFF
--- a/fragmentation_core/src/main/java/me/yokeyword/fragmentation/helper/internal/VisibleDelegate.java
+++ b/fragmentation_core/src/main/java/me/yokeyword/fragmentation/helper/internal/VisibleDelegate.java
@@ -135,7 +135,10 @@ public class VisibleDelegate {
     }
 
     private void dispatchSupportVisible(boolean visible) {
-        if (visible && isParentInvisible()) return;
+        if (visible && isParentInvisible()) {
+            mNeedDispatch = true;
+            return;
+        }
 
         if (mIsSupportVisible == visible) {
             mNeedDispatch = true;


### PR DESCRIPTION
刚打开的Fragment还没有执行onHidenChange的时候父Framgent就被隐藏了会导致mNeedDispatch标记位没有恢复